### PR TITLE
add `\n` char at the end of manifest files

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function bump(root, version, manifests){
     var path = resolve(root, key);
     var json = files[key];
     if (json.version) json.version = version;
-    write(path, JSON.stringify(json, null, 2));
+    write(path, JSON.stringify(json, null, 2) + '\n');
   });
 
   ret.version = version;


### PR DESCRIPTION
Because this is annoying:

![](https://cloudup.com/i2Qbj86U6lJ+)
